### PR TITLE
T4 hamlet keyword preserve white space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased changes]
 
-- Added syntax highlighting keyword to preserve white space
+- Added syntax highlighting keyword to preserve white space [#9](https://github.com/e-bigmoon/vscode-language-yesod/pull/9)
 - Indent-css content integrated into cassius (indent-css.tmLanguage.json has been deleted) [#8](https://github.com/e-bigmoon/vscode-language-yesod/pull/8)
 - Fixed syntax highlighting bug in route file [#7](https://github.com/e-bigmoon/vscode-language-yesod/pull/7)
 - Converted tmLanguage format files to JSON format [#5](https://github.com/e-bigmoon/vscode-language-yesod/pull/5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased changes]
 
+- Added syntax highlighting keyword to preserve white space
 - Indent-css content integrated into cassius (indent-css.tmLanguage.json has been deleted) [#8](https://github.com/e-bigmoon/vscode-language-yesod/pull/8)
 - Fixed syntax highlighting bug in route file [#7](https://github.com/e-bigmoon/vscode-language-yesod/pull/7)
 - Converted tmLanguage format files to JSON format [#5](https://github.com/e-bigmoon/vscode-language-yesod/pull/5)

--- a/sample/sample.hamlet
+++ b/sample/sample.hamlet
@@ -79,3 +79,8 @@ $doctype 5
 
     <p *{attrs}>
 
+    $# Preserve whitespace
+    <p>
+        Paragraph #
+        <i>italic
+        \ end.

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -54,7 +54,7 @@
           ]
         },
         {
-          "match": "\\s+#$|^\\s*\\\\\\s+",
+          "match": "#$|^\\s*\\\\",
           "name": "keyword.operator.hamlet"
         }
       ]

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -52,6 +52,10 @@
               "include": "source.haskell"
             }
           ]
+        },
+        {
+          "match": "\\s+#$|^\\s*\\\\\\s+",
+          "name": "keyword.operator.hamlet"
         }
       ]
     },


### PR DESCRIPTION
- fixes #4 

It will be as follows.

![T4-hamlet_preserved_whitespace](https://user-images.githubusercontent.com/61075211/77817115-a8469b80-710b-11ea-8060-5c83d15a85e9.png)
