### PR TITLE
T2 nesting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased changes]
 
+- Enabled highlighting of nested indents. It is doubtful that this is the right change. [#2](https://github.com/e-bigmoon/vscode-language-yesod/issues/2)
 - Added variable interpolation highlights [#1](https://github.com/e-bigmoon/vscode-language-yesod/issues/1)
 
 ## [0.6.0] - 2020-05-16

--- a/sample/sample.cassius
+++ b/sample/sample.cassius
@@ -13,3 +13,8 @@ section.blog
 
 ##{copy}
     margin: 1em
+
+div
+    font-size: 10px
+    a
+        font-size: 20px

--- a/syntaxes/cassius.tmLanguage.json
+++ b/syntaxes/cassius.tmLanguage.json
@@ -1497,6 +1497,9 @@
           "name": "meta.property-list.css",
           "patterns": [
             {
+              "include": "#selector-innards"
+            },
+            {
               "include": "#rule-list-innards"
             }
           ]
@@ -1755,8 +1758,8 @@
               "include": "#functional-pseudo-classes"
             },
             {
-              "match": "(?x) (?<![@\\w-])\n(?=            # Custom element names must:\n  [a-z]        # - start with a lowercase ASCII letter,\n  \\w* -       # - contain at least one dash\n)\n(?:\n  (?![A-Z])    # No uppercase ASCII letters are allowed\n  [\\w-]       # Allow any other word character or dash\n)+\n(?![(\\w-])",
-              "name": "entity.name.tag.custom.css"
+              ":match": "(?x) (?<![@\\w-])\n(?=            # Custom element names must:\n  [a-z]        # - start with a lowercase ASCII letter,\n  \\w* -       # - contain at least one dash\n)\n(?:\n  (?![A-Z])    # No uppercase ASCII letters are allowed\n  [\\w-]       # Allow any other word character or dash\n)+\n(?![(\\w-])",
+              ":name": "entity.name.tag.custom.css"
             }
           ]
         },


### PR DESCRIPTION
Changed to highlight the nests. fixes #2 
- before
![T2_before_cassius](https://user-images.githubusercontent.com/61075211/89701442-0dd84d80-d972-11ea-8eac-aa45e38c2b01.png)
-after
![T2_after_cassius](https://user-images.githubusercontent.com/61075211/89701445-13359800-d972-11ea-9606-a0102266b6da.png)

However, the highlighting of custom element names has been turned off.