### PR TITLE
Add line comments to .yesodroutes syntax highlighting

### DIFF
--- a/syntaxes/routes.tmLanguage.json
+++ b/syntaxes/routes.tmLanguage.json
@@ -30,6 +30,11 @@
               "name": "entity.other.attribute-name"
             }
           ]
+        },
+        {
+          "begin": "^--",
+          "end": "\n",
+          "name": "comment.line"
         }
       ]
     }

--- a/syntaxes/routes.tmLanguage.json
+++ b/syntaxes/routes.tmLanguage.json
@@ -28,6 +28,10 @@
             {
               "match": "![a-zA-Z0-9]+",
               "name": "entity.other.attribute-name"
+            },
+            {
+              "match": "--.*",
+              "name": "comment.line"
             }
           ]
         },


### PR DESCRIPTION
The documentation around the `.yesodroutes` file parsing is lacking, but it seems to ignore the remainder of lines starting at `--`. I propose we adjust the syntax highlighting to reflect this.