### PR TITLE
Support composite types in routes

### DIFF
--- a/syntaxes/routes.tmLanguage.json
+++ b/syntaxes/routes.tmLanguage.json
@@ -20,7 +20,7 @@
               "name": "meta.url.route.yesod",
               "patterns": [
                 {
-                  "match": "[#*+]!?[A-Z][a-zA-Z0-9]+",
+                  "match": "[#*+]!?[A-Z][a-zA-Z0-9-]+",
                   "name": "support.type.patterns"
                 },
                 {


### PR DESCRIPTION
Routes can have `PathPiece`s that are composite types, e.g. `/route/to/#Maybe-Int/page MyRouteR GET` uses a handler `getMyRouteR :: Maybe Int -> Handler Html`. This PR addresses the syntax highlighting to include the dashes between these types.

More info:
https://stackoverflow.com/questions/24352722/yesod-route-containing-a-maybe-a-argument