### PR TITLE
Hamlet TextMate rule improvements

### DIFF
--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -15,21 +15,19 @@
           "begin": "([_@#^\\*]|@\\?)\\{",
           "beginCaptures": {
             "0": {
-              "name": "punctuation.section.embedded.begin.hamlet"
+              "name": "punctuation.section.interpolation.begin.hamlet"
             }
           },
-          "contentName": "source.haskell",
+          "contentName": "source.haskell.embedded",
           "end": "(\\})",
           "endCaptures": {
             "0": {
-              "name": "punctuation.section.embedded.end.hamlet"
+              "name": "punctuation.section.interpolation.end.hamlet"
             }
           },
-          "name": "meta.embedded.line.hamlet",
+          "name": "meta.interpolation.hamlet",
           "patterns": [
-            {
-              "include": "source.haskell"
-            }
+            { "include": "source.haskell" }
           ]
         }
       ]
@@ -45,12 +43,11 @@
           "beginCaptures": {
             "0": { "name": "keyword.control.hamlet" }
           },
+          "contentName": "source.haskell.embedded",
           "end": "\\n",
-          "name": "meta.embedded.line.hamlet",
+          "name": "meta.interpolation.hamlet",
           "patterns": [
-            {
-              "include": "source.haskell"
-            }
+            { "include": "source.haskell" }
           ]
         },
         {
@@ -63,7 +60,7 @@
       "patterns": [
         {
           "match": "^\\s*\\$#.*$",
-          "name": "comment.line.$#.hamlet"
+          "name": "comment.line.hamlet"
         }
       ]
     },

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -79,22 +79,7 @@
           "name": "meta.tag.hamlet",
           "patterns": [
             { "include": "#attribute" },
-            { "include": "#interpolation" },
-            {
-              "match": "\\s(#|\\.)([^\\s>]+)",
-              "captures": {
-                "1": { "name": "entity.other.attribute-name.hamlet" },
-                "2": {
-                  "patterns": [
-                    { "include": "#interpolation" },
-                    {
-                      "match": "\\w",
-                      "name": "entity.other.attribute-name.hamlet"
-                    }
-                  ]
-                }
-              }
-            }
+            { "include": "#interpolation" }
           ]
         }
       ],
@@ -114,6 +99,15 @@
               },
               "patterns": [
                 { "include": "#interpolation" }
+              ]
+            },
+            {
+              "begin": "\\s(#|\\.)",
+              "end": "(?=(>|\\s))",
+              "name": "entity.other.attribute-name.hamlet",
+              "patterns": [
+                { "include": "#interpolation" },
+                { "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]" }
               ]
             }
           ]

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -67,9 +67,16 @@
     "tag": {
       "patterns": [
         {
-          "begin": "<[a-z]+",
-          "end": ">",
-          "name": "meta.embedded.line.hamlet",
+          "begin": "(<)([a-z]+)",
+          "beginCaptures": {
+            "1": { "name": "punctuation.definition.generic.begin.hamlet" },
+            "2": { "name": "entity.name.tag.hamlet" }
+          },
+          "end": "(>)",
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.generic.end.hamlet" }
+          },
+          "name": "meta.tag.hamlet",
           "patterns": [
             { "include": "#attribute" },
             { "include": "#interpolation" },

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -102,8 +102,19 @@
         "attribute": {
           "patterns": [
             {
-              "match": ":[^:]+:[^>]+",
-              "name": "entity.other.attribute-name.hamlet"
+              "begin": ":",
+              "beginCaptures": {
+                "0": { "name": "punctuation.section.interpolation.begin.hamlet" }
+              },
+              "contentName": "source.haskell.embedded",
+              "end": "(:)(.+?)(?=(>|\\s))",
+              "endCaptures": {
+                "1": { "name": "punctuation.section.interpolation.end.hamlet" },
+                "2": { "name": "entity.other.attribute-name.hamlet" }
+              },
+              "patterns": [
+                { "include": "#interpolation" }
+              ]
             }
           ]
         }

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -60,7 +60,7 @@
       "patterns": [
         {
           "match": "^\\s*\\$#.*$",
-          "name": "comment.line.hamlet"
+          "name": "comment.line.$#.hamlet"
         }
       ]
     },
@@ -72,14 +72,30 @@
             "1": { "name": "punctuation.definition.generic.begin.hamlet" },
             "2": { "name": "entity.name.tag.hamlet" }
           },
-          "end": "(>)",
+          "end": ">",
           "endCaptures": {
-            "1": { "name": "punctuation.definition.generic.end.hamlet" }
+            "0": { "name": "punctuation.definition.generic.end.hamlet" }
           },
           "name": "meta.tag.hamlet",
           "patterns": [
-            { "include": "#attribute" },
-            { "include": "#interpolation" }
+            { "include": "#interpolation" },
+            {
+              "begin": "(?<==)\"",
+              "end": "\"",
+              "name": "string.quoted.double.hamlet",
+              "patterns": [
+                { "include": "#interpolation" }
+              ]
+            },
+            {
+              "begin": "(?<==)'",
+              "end": "'",
+              "name": "string.quoted.single.hamlet",
+              "patterns": [
+                { "include": "#interpolation" }
+              ]
+            },
+            { "include": "#attribute" }
           ]
         }
       ],

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -108,7 +108,7 @@
                 "0": { "name": "punctuation.section.interpolation.begin.hamlet" }
               },
               "contentName": "source.haskell.embedded",
-              "end": "(:)(.+?)(?=(>|\\s))",
+              "end": "(:)(.*?)(?=(>|\\s))",
               "endCaptures": {
                 "1": { "name": "punctuation.section.interpolation.end.hamlet" },
                 "2": { "name": "entity.other.attribute-name.hamlet" }


### PR DESCRIPTION
Hello! This pull request addresses several bugs in the Hamlet syntax highlighting.

Let me begin with a side-by-side comparison of the syntax highlighting with current master and with my changes.

Current master:
![hamlet-syntax-old](https://user-images.githubusercontent.com/18196871/115121529-4a3c5e80-9f81-11eb-882b-5d1fdb9751e6.png)

bi-functor/conditional-attribute-highlight:
![hamlet-syntax-new](https://user-images.githubusercontent.com/18196871/115121567-68a25a00-9f81-11eb-85ae-bd69b0c5efc4.png)

The most noticeable change is on line 6. Conditional attributes no longer highlight the entire row: in between the colons is formatted as interpolated code, and only the attribute following the second colon is highlighted as such.

Attribute properties in string format, such as `"button"` on line 13, are highlighted in a separate colour as well. They permit interpolation within themselves as well as evidenced on line 6.

Tag names are now specially highlighted, to distinguish them from attributes.

Also, CSS class selectors now highlight the dashes between words, not just the underscores.

Some scopes have been renamed according to [the Sublime Text Scope Naming guide](https://www.sublimetext.com/docs/3/scope_naming.html): mostly replacing `embedded` with `interpolation` and making sure that interpolated Haskell source code has the proper name (`source.haskell.embedded`).