### PR TITLE
Hamlet attribute scope names

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "language-yesod",
   "displayName": "Language Yesod",
   "description": "Syntax highlighting for the Haskell Yesod web framework",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "publisher": "BIGMOON",
   "license": "BSD-3-Clause",
   "private": true,

--- a/sample/sample.hamlet
+++ b/sample/sample.hamlet
@@ -9,7 +9,7 @@ $doctype 5
 <html>
     <head>
         <title>#{pageTitle} - My Site
-        <link rel=stylesheet href=@{Stylesheet}>
+        <link rel=stylesheet href=@{Stylesheet} data-extra="something">
     <body>
         <h1 .page-title>#{pageTitle}
         <p>Here is a list of your friends:
@@ -62,7 +62,7 @@ $doctype 5
     <div ##{xxx}>
 
     <p>@{Stylesheet}
-    <a href=@?{(SomePage, [("page", pack $ show $ currPage + 1)])} data-link-extra="something">
+    <a href=@?{(SomePage, [("page", pack $ show $ currPage + 1)])}>
     <p>_{Hello}
     <p>^{addBling}
 

--- a/sample/sample.hamlet
+++ b/sample/sample.hamlet
@@ -62,7 +62,7 @@ $doctype 5
     <div ##{xxx}>
 
     <p>@{Stylesheet}
-    <a href=@?{(SomePage, [("page", pack $ show $ currPage + 1)])}>
+    <a href=@?{(SomePage, [("page", pack $ show $ currPage + 1)])} data-link-extra="something">
     <p>_{Hello}
     <p>^{addBling}
 
@@ -70,7 +70,7 @@ $doctype 5
     <input type=checkbox checked>
     
     <p #paragraphid .class1 .class2>
-    <img src=https://example.com/images/a.jpg>
+    <img src="https://example.com/images/a.jpg">
 
     <input type=checkbox :isChecked:checked>
     <p :isRed:style="color:red">

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -104,7 +104,7 @@
               "include": "#interpolation"
             },
             {
-              "begin": "(?<==)\"",
+              "begin": "(?<=\\s*=)\"",
               "end": "\"",
               "name": "string.quoted.double.hamlet",
               "patterns": [
@@ -114,7 +114,7 @@
               ]
             },
             {
-              "begin": "(?<==)'",
+              "begin": "(?<=\\s*=)'",
               "end": "'",
               "name": "string.quoted.single.hamlet",
               "patterns": [
@@ -156,18 +156,18 @@
               "begin": "(?<=\\s|:)#",
               "beginCaptures": {
                 "0": {
-                  "name": "entity.other.attribute-name.hamlet"
+                  "name": "meta.attribute.id.hamlet"
                 }
               },
               "end": "(?=(>|\\s))",
-              "name": "meta.attribute.id.hamlet",
+              "name": "entity.other.attribute-name.hamlet",
               "patterns": [
                 {
                   "include": "#interpolation"
                 },
                 {
                   "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]",
-                  "name": "entity.other.attribute-name.hamlet"
+                  "name": "meta.attribute.id.hamlet"
                 }
               ]
             },
@@ -175,38 +175,43 @@
               "begin": "(?<=\\s|:)\\.",
               "beginCaptures": {
                 "0": {
-                  "name": "entity.other.attribute-name.hamlet"
+                  "name": "meta.attribute.class.hamlet"
                 }
               },
               "end": "(?=(>|\\s))",
-              "name": "meta.attribute.class.hamlet",
+              "name": "entity.other.attribute-name.hamlet",
               "patterns": [
                 {
                   "include": "#interpolation"
                 },
                 {
                   "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]",
-                  "name": "entity.other.attribute-name.hamlet"
+                  "name": "meta.attribute.class.hamlet"
                 }
               ]
             },
             {
-              "begin": "(?<=\\s|:)(\\w+)(?=\\s*=)",
+              "begin": "(?<=\\s|:)(\\w+)(?=\\s|=|>)",
               "beginCaptures": {
-                "0": {
-                  "name": "entity.other.attribute-name.hamlet"
+                "1": {
+                  "name": "meta.attribute.$1.hamlet"
                 }
               },
-              "end": "(?=\\s*+[^=\\s])",
-              "name": "meta.attribute.$1.hamlet",
+              "end": "(?=\\s*[=\\s>])",
+              "name": "entity.other.attribute-name.hamlet",
               "patterns": [
                 {
                   "include": "#interpolation"
                 },
                 {
-                  "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]"
+                  "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]",
+                  "name": "meta.attribute.$1.hamlet"
                 }
               ]
+            },
+            {
+              "match": "=",
+              "name": "punctuation.separator.key-value.hamlet"
             }
           ]
         }

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -191,7 +191,7 @@
               ]
             },
             {
-              "begin": "(?<=\\s|:)(\\w+)(?=\\s|=|>)",
+              "begin": "(?<=\\s|:)([\\w-]+)(?=\\s|=|>)",
               "beginCaptures": {
                 "1": {
                   "name": "meta.attribute.$1.hamlet"

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -86,7 +86,7 @@
           "begin": "(<)([a-z0-9]+)",
           "beginCaptures": {
             "1": {
-              "name": "punctuation.definition.generic.begin.hamlet"
+              "name": "punctuation.definition.tag.begin.hamlet"
             },
             "2": {
               "name": "entity.name.tag.hamlet"
@@ -95,7 +95,7 @@
           "end": ">",
           "endCaptures": {
             "0": {
-              "name": "punctuation.definition.generic.end.hamlet"
+              "name": "punctuation.definition.tag.end.hamlet"
             }
           },
           "name": "meta.tag.hamlet",
@@ -125,13 +125,7 @@
             },
             {
               "include": "#attribute"
-            }
-          ]
-        }
-      ],
-      "repository": {
-        "attribute": {
-          "patterns": [
+            },
             {
               "begin": ":",
               "beginCaptures": {
@@ -140,13 +134,10 @@
                 }
               },
               "contentName": "source.haskell.embedded",
-              "end": "(:)(.*?)(?=(>|\\s))",
+              "end": ":",
               "endCaptures": {
-                "1": {
+                "0": {
                   "name": "punctuation.section.interpolation.end.hamlet"
-                },
-                "2": {
-                  "name": "entity.other.attribute-name.hamlet"
                 }
               },
               "patterns": [
@@ -154,9 +145,15 @@
                   "include": "#interpolation"
                 }
               ]
-            },
+            }
+          ]
+        }
+      ],
+      "repository": {
+        "attribute": {
+          "patterns": [
             {
-              "begin": "(?<=\\s)#",
+              "begin": "(?<=\\s|:)#",
               "beginCaptures": {
                 "0": {
                   "name": "entity.other.attribute-name.hamlet"
@@ -175,7 +172,7 @@
               ]
             },
             {
-              "begin": "(?<=\\s)\\.",
+              "begin": "(?<=\\s|:)\\.",
               "beginCaptures": {
                 "0": {
                   "name": "entity.other.attribute-name.hamlet"
@@ -194,7 +191,7 @@
               ]
             },
             {
-              "begin": "(?<=\\s)(\\w+)(?=\\s*=)",
+              "begin": "(?<=\\s|:)(\\w+)(?=\\s*=)",
               "beginCaptures": {
                 "0": {
                   "name": "entity.other.attribute-name.hamlet"

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -1,12 +1,22 @@
 {
   "scopeName": "source.yesod.hamlet",
-  "fileTypes": ["hamlet"],
+  "fileTypes": [
+    "hamlet"
+  ],
   "name": "Yesod Hamlet",
   "patterns": [
-    { "include": "#interpolation" },
-    { "include": "#keyword" },
-    { "include": "#comment" },
-    { "include": "#tag" }
+    {
+      "include": "#interpolation"
+    },
+    {
+      "include": "#keyword"
+    },
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#tag"
+    }
   ],
   "repository": {
     "interpolation": {
@@ -27,7 +37,9 @@
           },
           "name": "meta.interpolation.hamlet",
           "patterns": [
-            { "include": "source.haskell" }
+            {
+              "include": "source.haskell"
+            }
           ]
         }
       ]
@@ -41,13 +53,17 @@
         {
           "begin": "\\$(if|elseif|maybe|forall|case|of|with)\\s+",
           "beginCaptures": {
-            "0": { "name": "keyword.control.hamlet" }
+            "0": {
+              "name": "keyword.control.hamlet"
+            }
           },
           "contentName": "source.haskell.embedded",
           "end": "\\n",
           "name": "meta.interpolation.hamlet",
           "patterns": [
-            { "include": "source.haskell" }
+            {
+              "include": "source.haskell"
+            }
           ]
         },
         {
@@ -69,22 +85,32 @@
         {
           "begin": "(<)([a-z]+)",
           "beginCaptures": {
-            "1": { "name": "punctuation.definition.generic.begin.hamlet" },
-            "2": { "name": "entity.name.tag.hamlet" }
+            "1": {
+              "name": "punctuation.definition.generic.begin.hamlet"
+            },
+            "2": {
+              "name": "entity.name.tag.hamlet"
+            }
           },
           "end": ">",
           "endCaptures": {
-            "0": { "name": "punctuation.definition.generic.end.hamlet" }
+            "0": {
+              "name": "punctuation.definition.generic.end.hamlet"
+            }
           },
           "name": "meta.tag.hamlet",
           "patterns": [
-            { "include": "#interpolation" },
+            {
+              "include": "#interpolation"
+            },
             {
               "begin": "(?<==)\"",
               "end": "\"",
               "name": "string.quoted.double.hamlet",
               "patterns": [
-                { "include": "#interpolation" }
+                {
+                  "include": "#interpolation"
+                }
               ]
             },
             {
@@ -92,10 +118,14 @@
               "end": "'",
               "name": "string.quoted.single.hamlet",
               "patterns": [
-                { "include": "#interpolation" }
+                {
+                  "include": "#interpolation"
+                }
               ]
             },
-            { "include": "#attribute" }
+            {
+              "include": "#attribute"
+            }
           ]
         }
       ],
@@ -105,16 +135,24 @@
             {
               "begin": ":",
               "beginCaptures": {
-                "0": { "name": "punctuation.section.interpolation.begin.hamlet" }
+                "0": {
+                  "name": "punctuation.section.interpolation.begin.hamlet"
+                }
               },
               "contentName": "source.haskell.embedded",
               "end": "(:)(.*?)(?=(>|\\s))",
               "endCaptures": {
-                "1": { "name": "punctuation.section.interpolation.end.hamlet" },
-                "2": { "name": "entity.other.attribute-name.hamlet" }
+                "1": {
+                  "name": "punctuation.section.interpolation.end.hamlet"
+                },
+                "2": {
+                  "name": "entity.other.attribute-name.hamlet"
+                }
               },
               "patterns": [
-                { "include": "#interpolation" }
+                {
+                  "include": "#interpolation"
+                }
               ]
             },
             {
@@ -122,8 +160,12 @@
               "end": "(?=(>|\\s))",
               "name": "entity.other.attribute-name.hamlet",
               "patterns": [
-                { "include": "#interpolation" },
-                { "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]" }
+                {
+                  "include": "#interpolation"
+                },
+                {
+                  "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]"
+                }
               ]
             }
           ]

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -156,9 +156,52 @@
               ]
             },
             {
-              "begin": "\\s(#|\\.)",
+              "begin": "(?<=\\s)#",
+              "beginCaptures": {
+                "0": {
+                  "name": "entity.other.attribute-name.hamlet"
+                }
+              },
               "end": "(?=(>|\\s))",
-              "name": "entity.other.attribute-name.hamlet",
+              "name": "meta.attribute.id.hamlet",
+              "patterns": [
+                {
+                  "include": "#interpolation"
+                },
+                {
+                  "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]",
+                  "name": "entity.other.attribute-name.hamlet"
+                }
+              ]
+            },
+            {
+              "begin": "(?<=\\s)\\.",
+              "beginCaptures": {
+                "0": {
+                  "name": "entity.other.attribute-name.hamlet"
+                }
+              },
+              "end": "(?=(>|\\s))",
+              "name": "meta.attribute.class.hamlet",
+              "patterns": [
+                {
+                  "include": "#interpolation"
+                },
+                {
+                  "match": "-?[_a-zA-Z]+[_a-zA-Z0-9-]",
+                  "name": "entity.other.attribute-name.hamlet"
+                }
+              ]
+            },
+            {
+              "begin": "(?<=\\s)(\\w+)(?=\\s*=)",
+              "beginCaptures": {
+                "0": {
+                  "name": "entity.other.attribute-name.hamlet"
+                }
+              },
+              "end": "(?=\\s*+[^=\\s])",
+              "name": "meta.attribute.$1.hamlet",
               "patterns": [
                 {
                   "include": "#interpolation"

--- a/syntaxes/hamlet.tmLanguage.json
+++ b/syntaxes/hamlet.tmLanguage.json
@@ -83,7 +83,7 @@
     "tag": {
       "patterns": [
         {
-          "begin": "(<)([a-z]+)",
+          "begin": "(<)([a-z0-9]+)",
           "beginCaptures": {
             "1": {
               "name": "punctuation.definition.generic.begin.hamlet"


### PR DESCRIPTION
This PR addresses minor inconsistencies between HTML and Hamlet syntax highlighting within tags, specifically regarding the naming of scopes.

Attributes now support self-named scopes, e.g. the `href` in `href="..."` will have leftmost scope `meta.attribute.href.hamlet`, followed by `entity.other.attribute-name.hamlet`. The same applies to conditional attributes. For IDs and classes written in CSS selector syntax, e.g. `#tag-id` and `.tag-class`, these will have only `meta.attribute.id.hamlet` and `.meta.attribute.class.hamlet` respectively.

Now, `=` is given the same scope as in HTML, which is `punctuation.separator.key-value`.

Also, digits are permitted in tag names (so h1..h6, etc are highlighted properly).