### PR TITLE
Add Haskell Syntax Highlighting as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Add Haskell Syntax Highlighting as a dependency [#54](https://github.com/e-bigmoon/vscode-language-yesod/pull/54) @isao-takejib
+
 ## [0.9.0] - 2021-10-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "categories": [
     "Programming Languages"
   ],
+  "extensionDependencies": [
+    "justusadam.language-haskell"
+  ],
   "contributes": {
     "languages": [
       {


### PR DESCRIPTION
fixes #53 

- Add [Haskell Syntax Highlighting](https://marketplace.visualstudio.com/items?itemName=justusadam.language-haskell)